### PR TITLE
Improve configuration and add print log endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your values
+DATABASE_URL=postgres://user:pass@localhost:5432/printtracker
+PORT=5000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# Print-tracker
+# Print Tracker
+
+Print Tracker is a full-stack application for tracking print jobs in architecture studios. It includes:
+
+- **Server** – Express API and React client served from the same Node process
+- **Client** – React frontend built with Vite
+- **Print Monitor** – Windows utility that validates print jobs and logs them to the API
+
+## Requirements
+- Node.js 18+
+- PostgreSQL database
+- .NET Framework for building the Windows utility
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and fill in the values:
+   ```bash
+   cp .env.example .env
+   ```
+   - `DATABASE_URL` – connection string for your Postgres database
+   - `PORT` – port for the API and client (defaults to `5000`)
+3. Push the database schema with Drizzle:
+   ```bash
+   npm run db:push
+   ```
+4. Start the application in development mode:
+   ```bash
+   npm run dev
+   ```
+   The server and client will be available at `http://localhost:PORT`.
+
+For production, build and start:
+```bash
+npm run build
+npm start
+```
+
+## Windows Print Monitor
+The `print-monitor` folder contains a Windows application that validates print jobs and sends log data to the server. Configure the API URL via the `PRINTTRACK_API_URL` environment variable (defaults to `http://localhost:5000`).
+
+Build the utility with Visual Studio or the `csc` command:
+```bash
+csc PrintMonitor.cs
+```
+
+## Running Tests
+A basic test suite is included using Vitest. Run all tests with:
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/print-monitor/PrintMonitor.cs
+++ b/print-monitor/PrintMonitor.cs
@@ -13,13 +13,14 @@ namespace PrintTrackMonitor
     public partial class PrintMonitorForm : Form
     {
         private readonly HttpClient client;
-        private const string API_URL = "http://your-printtrack-server:5000";
+        private readonly string apiUrl;
         private Dictionary<string, decimal> paperCosts;
 
         public PrintMonitorForm()
         {
             InitializeComponent();
             client = new HttpClient();
+            apiUrl = Environment.GetEnvironmentVariable("PRINTTRACK_API_URL") ?? "http://localhost:5000";
             InitializePrintMonitor();
             InitializePaperCosts();
         }
@@ -156,7 +157,7 @@ namespace PrintTrackMonitor
             try
             {
                 // Validate job number with API
-                var response = await client.GetAsync($"{API_URL}/api/print-jobs/{details.JobNumber}");
+                var response = await client.GetAsync($"{apiUrl}/api/print-jobs/{details.JobNumber}");
                 if (!response.IsSuccessStatusCode)
                 {
                     MessageBox.Show("Invalid job number. Please enter a valid print job number.");
@@ -214,7 +215,7 @@ namespace PrintTrackMonitor
                 };
 
                 await client.PostAsync(
-                    $"{API_URL}/api/print-logs",
+                    $"{apiUrl}/api/print-logs",
                     new StringContent(
                         System.Text.Json.JsonSerializer.Serialize(data),
                         System.Text.Encoding.UTF8,

--- a/server/index.ts
+++ b/server/index.ts
@@ -56,9 +56,8 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client
-  const PORT = 5000;
+  // Serve the API and client on the configured port
+  const PORT = process.env.PORT ? Number(process.env.PORT) : 5000;
   server.listen(PORT, "0.0.0.0", () => {
     log(`serving on port ${PORT}`);
   });

--- a/server/routes.test.js
+++ b/server/routes.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import request from 'supertest';
+import { registerRoutes } from './routes.js';
+import { storage } from './storage.js';
+
+test('GET /api/print-logs returns logs', async (t) => {
+  const app = express();
+  app.use(express.json());
+  storage.getPrintLogs = async () => [{ id: 1 }];
+  const server = await registerRoutes(app);
+
+  const res = await request(server).get('/api/print-logs');
+  assert.equal(res.statusCode, 200);
+  assert.deepStrictEqual(res.body, [{ id: 1 }]);
+
+  server.close();
+  t.pass();
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -76,6 +76,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.json(time);
   });
 
+  // Print Logs
+  app.get("/api/print-logs", async (req, res) => {
+    const printJobId = req.query.printJobId
+      ? Number(req.query.printJobId)
+      : undefined;
+    const logs = await storage.getPrintLogs(printJobId);
+    res.json(logs);
+  });
+
   // Print Monitor Integration
   app.post("/api/print-logs", async (req, res) => {
     const { 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- write full README with setup and test instructions
- provide example environment variables
- make server port configurable
- add endpoint for retrieving print logs
- make print-monitor configurable via env var
- set up simple Node test

## Testing
- `npm test --silent` *(fails: Cannot find package '/workspace/Print-tracker/node_modules/express/index.js' imported from /workspace/Print-tracker/server/routes.test.js)*